### PR TITLE
Show "Game Over" text notification before finishing game.

### DIFF
--- a/app/src/main/java/info/hebbeker/david/memorex/MainActivity.java
+++ b/app/src/main/java/info/hebbeker/david/memorex/MainActivity.java
@@ -19,6 +19,7 @@ public class MainActivity extends AppCompatActivity implements GameBoardInterfac
     private final SymbolButton[] symbols = new SymbolButton[4];
     private final Game game = new Game(this, symbols);
     private View startGameButton;
+    private Toast notification = null;
 
     @Override
     protected void onCreate(final Bundle savedInstanceState)
@@ -102,7 +103,11 @@ public class MainActivity extends AppCompatActivity implements GameBoardInterfac
     @Override
     public void notifyUser(final String userMessage)
     {
-        Toast notification = Toast.makeText(this, userMessage, Toast.LENGTH_LONG);
+        if (notification != null) // check if a notification has been created before
+        {
+            notification.cancel(); // cancel potential previous notification
+        }
+        notification = Toast.makeText(this, userMessage, Toast.LENGTH_LONG);
         notification.show();
     }
 


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against `master`
- [x] My code follows the [style guide](../.idea/codeStyleSettings.xml)
- [x] My code does not introduce new warnings or errors

## The details
### Proposed Changes
Let the [`Toast`][]s cancel each other out.

[`Toast`]: https://developer.android.com/reference/android/widget/Toast.html

### Reason for Changes
In case the text notifications are queued, the "Game Over" notification may be shown too late to the user. This change is related to #1.

### Test Coverage
Tested on:
- Device:
  - Samsung Galaxy S2
  - Samsung Galasy A3
- Android platform:
  - Android 4.1.2
  - Android 7.0
