### PR TITLE
Improve the notification at the end of a game

### DIFF
--- a/app/src/main/java/info/hebbeker/david/memorex/EndOfGameDialogFragment.java
+++ b/app/src/main/java/info/hebbeker/david/memorex/EndOfGameDialogFragment.java
@@ -1,0 +1,46 @@
+package info.hebbeker.david.memorex;
+
+import android.app.AlertDialog;
+import android.app.Dialog;
+import android.app.DialogFragment;
+import android.os.Bundle;
+
+import java.io.Serializable;
+
+public class EndOfGameDialogFragment extends DialogFragment
+{
+    public final static String keyLastScore = "KEY_LAST_SCORE";
+    public final static String keyCurrentHighScore = "KEY_CURRENT_HIGH_SCORE";
+    public final static String keyIsNewHighScore = "KEY_IS_NEW_HIGH_SCORE";
+    private Serializable lastScore = null;
+    private Serializable currentHighScore = null;
+    private boolean isNewHighScore = false;
+
+    @Override
+    public void setArguments(Bundle args)
+    {
+        super.setArguments(args);
+        this.lastScore = args.getSerializable(keyLastScore);
+        this.currentHighScore = args.getSerializable(keyCurrentHighScore);
+        this.isNewHighScore = args.getBoolean(keyIsNewHighScore);
+    }
+
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState)
+    {
+        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+        builder.setTitle("Game Over!");
+        String message = "Your score is: " + lastScore.toString() + '\n';
+        if (isNewHighScore)
+        {
+            /* https://unicode.org/emoji/charts/full-emoji-list.html#1f389 */
+            final String partyPopper = "\uD83C\uDF89";
+            message += "Congratulations, this is a new high score! " + partyPopper;
+        } else
+        {
+            message += "The current high score is: " + currentHighScore.toString();
+        }
+        builder.setMessage(message);
+        return builder.create();
+    }
+}

--- a/app/src/main/java/info/hebbeker/david/memorex/Game.java
+++ b/app/src/main/java/info/hebbeker/david/memorex/Game.java
@@ -28,6 +28,8 @@ interface GameBoardInterface
      */
     void notifyUser(final String userMessage);
 
+    void showEndOfGameDialog(final Score score);
+
     /**
      * Set game board to a state where the player sees all symbols.
      */
@@ -68,7 +70,7 @@ final class Game
         gameBoardInterface.queueDisplaySymbolSequence(symbolSequence);
     }
 
-    void putPlayerInput(final Symbol symbol, final HighScoreContainer highScoreContainer)
+    void putPlayerInput(final Symbol symbol)
     {
         // if input symbol is not correct, notify user and reset board game
         if (symbol != currentSymbol.next())
@@ -76,8 +78,7 @@ final class Game
             // end current game
             final int completedLevel = symbolSequence.size() - 1;
             final Score score = new Score(completedLevel);
-            highScoreContainer.setNewHighScore(score);
-            gameBoardInterface.notifyUser("Game Over (" + completedLevel + ")");
+            gameBoardInterface.showEndOfGameDialog(score);
             gameBoardInterface.clearBoard();
         }
         // if sequence is complete, notify user and start next level

--- a/app/src/main/java/info/hebbeker/david/memorex/MainActivity.java
+++ b/app/src/main/java/info/hebbeker/david/memorex/MainActivity.java
@@ -1,5 +1,6 @@
 package info.hebbeker.david.memorex;
 
+import android.app.DialogFragment;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
@@ -59,7 +60,7 @@ public class MainActivity extends AppCompatActivity implements GameBoardInterfac
     {
         SymbolButton pressedButton = (SymbolButton) view;
         pressedButton.signalSymbol(); // signal symbol to user
-        game.putPlayerInput(pressedButton, highScoreContainer); // signal symbol to game
+        game.putPlayerInput(pressedButton); // signal symbol to game
     }
 
     public void startGame(@SuppressWarnings("unused") final View view)
@@ -113,6 +114,22 @@ public class MainActivity extends AppCompatActivity implements GameBoardInterfac
         }
         notification = Toast.makeText(this, userMessage, Toast.LENGTH_LONG);
         notification.show();
+    }
+
+    @Override
+    public void showEndOfGameDialog(final Score score)
+    {
+        final boolean isNewHighScore = highScoreContainer.setNewHighScore(score);
+        DialogFragment endOfGameDialog = new EndOfGameDialogFragment();
+
+        /* the arguments for the dialog need to be put into a bundle */
+        final Bundle dialogArguments = new Bundle(3);
+        dialogArguments.putSerializable(EndOfGameDialogFragment.keyLastScore, score);
+        dialogArguments.putSerializable(EndOfGameDialogFragment.keyCurrentHighScore, highScoreContainer.getCurrentHighScore());
+        dialogArguments.putBoolean(EndOfGameDialogFragment.keyIsNewHighScore, isNewHighScore);
+        endOfGameDialog.setArguments(dialogArguments);
+
+        endOfGameDialog.show(getFragmentManager(), EndOfGameDialogFragment.class.getCanonicalName());
     }
 
     @Override


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against `master`
- [x] My code follows the [style guide](../.idea/codeStyleSettings.xml)
- [x] My code does not introduce new warnings or errors

## The details
### Proposed Changes
Instead of using the [`Toast`][] text notification a dialog is now shown at the end of a game. This dialog shows the achieved score.

[`Toast`]: https://developer.android.com/guide/topics/ui/notifiers/toasts.html
### Reason for Changes
This change shall fix #1.

### Test Coverage
Tested on:
 - Samsung GT-I9100G (Android 4.1.2)
 - Samsung SM-A310F (Android 7.0)

### Additional Information
- Can be tested with this [app-release-v1.1.1-bugfix-end-of-game-display-1.apk][1]
- This is what it looks like: <img src="https://user-images.githubusercontent.com/1594340/37567665-6b5bdeb2-2aca-11e8-8514-1b80165c3d71.png" height=300>

[1]: https://github.com/dhebbeker/memorex-android/releases/download/v1.1.1-bugfix-end-of-game-display.1/app-release-v1.1.1-bugfix-end-of-game-display-1.apk