### PR TITLE
Unification of title display of 'About this App' Activity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,6 +19,7 @@
         </activity>
         <activity
             android:name=".DisplayAboutActivity"
+            android:label="@string/about_this_app"
             android:parentActivityName=".MainActivity"
             tools:ignore="UnusedAttribute">
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,9 +1,8 @@
 <resources>
     <string name="app_name" translatable="false">Memorex</string>
-    <string name="start_string_app_name">start @string/app_name</string>
-    <string name="about_this_app">About this app</string>
-    <string name="about_text">"&lt;h1>About Memorex&lt;/h1>
-&lt;u>Project website:&lt;/u> https://david.hebbeker.info/memorex&lt;br/>
+    <string name="start_string_app_name">start Memorex</string>
+    <string name="about_this_app">About Memorex</string>
+    <string name="about_text">"&lt;u>Project website:&lt;/u> https://david.hebbeker.info/memorex&lt;br/>
 &lt;u>version name:&lt;/u> %1$s"
 </string>
     <!-- Strings related to Settings -->


### PR DESCRIPTION
## The basics

- [x] I branched from develop
- [x] My pull request is against `master`
- [x] My code follows the [style guide](../.idea/codeStyleSettings.xml)
- [x] My code does not introduce new warnings or errors

## The details
### Proposed Changes
Moved title from the 'about' text to the title of the activity.

### Reason for Changes
This way the design of the Activities is more uniform.

### Test Coverage
Tested on:
 - Samsung GT-I9100G (Android 4.1.2)
 - Samsung SM-A310F (Android 7.0)

### Additional Information
- Can be tested with this [APK][1]

[1]: https://github.com/dhebbeker/memorex-android/releases/download/v1.2.0-0.develop%2Bfeature-cleanup-about.5.g8a351b9/memorex-v1.2.0-0.develop.feature-cleanup-about.5.g8a351b9.apk